### PR TITLE
chore(deps): bump github.com/ctfer-io/terraform-provider-ctfd to v2.8.1

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20240202163305-e2a20ae13ef9
 
 require (
-	github.com/ctfer-io/terraform-provider-ctfd/v2 v2.8.0
+	github.com/ctfer-io/terraform-provider-ctfd/v2 v2.8.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.109.0
 	go.opentelemetry.io/contrib/exporters/autoexport v0.68.0
 	go.opentelemetry.io/otel v1.43.0
@@ -47,7 +47,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
-	github.com/ctfer-io/go-ctfd v0.17.0 // indirect
+	github.com/ctfer-io/go-ctfd v0.18.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/djherbis/times v1.5.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -329,10 +329,10 @@ github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/ctfer-io/go-ctfd v0.17.0 h1:qu/FHjlOSdhRMtHB66OFzHwOnwLwHrr9w4n8EHo8Yhs=
-github.com/ctfer-io/go-ctfd v0.17.0/go.mod h1:A8Mgqm85JtaTEVX8a0ZvHefcL6Nq2Ip2neftdfkgu18=
-github.com/ctfer-io/terraform-provider-ctfd/v2 v2.8.0 h1:78nlWeF8qrNmT6ccTS2yVD8veDISFPNzaqzDJAlOHgg=
-github.com/ctfer-io/terraform-provider-ctfd/v2 v2.8.0/go.mod h1:tWZ6MrUhYRVsd4T5U4K6LPhZST98L/+0eMJ7BYcZmKc=
+github.com/ctfer-io/go-ctfd v0.18.0 h1:rcP1rrIR4DefLOVYd7zM5NNtfB2pHivFfj6odUIZOv0=
+github.com/ctfer-io/go-ctfd v0.18.0/go.mod h1:A8Mgqm85JtaTEVX8a0ZvHefcL6Nq2Ip2neftdfkgu18=
+github.com/ctfer-io/terraform-provider-ctfd/v2 v2.8.1 h1:HWDOaXfA3gbupcjIxJ8obV9Z5QWtF6lsoLw2+603wHw=
+github.com/ctfer-io/terraform-provider-ctfd/v2 v2.8.1/go.mod h1:T2U0EhiteXgwJ9P13uegntkqp9Y8lUTouefOy0qsLMA=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Bump TF provider for support of pagination for applicable datasources.